### PR TITLE
feat: Publisher interface and adapter event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ them with `runnable.WithAdapters` (left-to-right = outermost-to-innermost):
 ```go
 r := runnable.New(reconcile, runnable.WithAdapters(
     adapters.Draining(10*time.Second),
-    adapters.Recovering(reportPanic),
+    adapters.Recovering(),
     adapters.Retry(3, time.Minute),
     adapters.Ticker(30*time.Second),
 ))
@@ -116,12 +116,13 @@ cancelled or the work returns an error. Composes with Draining: an
 in-flight tick is allowed to finish before the loop exits.
 
 **Recovering** — turns panics in the wrapped work into errors and
-invokes the optional handler before returning. Place inside Draining
-when both are in use.
+emits a `runnable.PanicRecoveredEvent` to the Publisher on ctx. Place
+inside Draining when both are in use.
 
 **Retry** — re-invokes the wrapped work up to `maxRetries` times on
 non-context errors. If `resetAfter` is non-zero and at least that long
-has passed since the previous attempt, the retry budget resets.
+has passed since the previous attempt, the retry budget resets. Emits
+a `runnable.RetryEvent` after each failed attempt.
 
 Inside long-running work, always select on both `ctx.Done()` and
 `adapters.Stopping(ctx)` — `Stopping` signals drain start, `ctx.Done()`
@@ -129,6 +130,38 @@ fires only when the drain timer expires.
 
 A full SIGTERM-safe service shape lives in
 [`examples/ticker-with-drain`](examples/ticker-with-drain/main.go).
+
+### Observability via Publisher
+
+Adapters emit typed events to a `runnable.Publisher` installed on the
+runnable's ctx. Use `runnable.WithPublisher` to register one (or many —
+multiple `WithPublisher` calls fan out):
+
+```go
+type log struct{}
+
+func (log) Publish(event any) {
+    switch ev := event.(type) {
+    case runnable.RetryEvent:
+        fmt.Printf("retry attempt %d: %v\n", ev.Attempt, ev.Err)
+    case runnable.DrainStartedEvent:
+        fmt.Printf("drain started, %s window\n", ev.Timeout)
+    case runnable.PanicRecoveredEvent:
+        fmt.Fprintf(os.Stderr, "panic: %v\n%s", ev.Recovered, ev.Stack)
+    }
+}
+
+r := runnable.New(work,
+    runnable.WithPublisher(log{}),
+    runnable.WithAdapters(adapters.Retry(3, time.Minute), adapters.Recovering()),
+)
+```
+
+`StatusStore` is a Publisher too — `WithStatus(id, store)` wires it
+automatically and counts `RetryEvent`s into `Status.Restarts`.
+
+`Publisher.Publish` runs on the caller's goroutine, so subscribers must
+not block. Buffer internally if you need async dispatch.
 
 ### Migrating from v0.1 to v0.2
 
@@ -149,7 +182,7 @@ After (v0.2):
 
     r := runnable.New(doWork, runnable.WithAdapters(
         adapters.Draining(10*time.Second),
-        adapters.Recovering(handler),
+        adapters.Recovering(),
         adapters.Retry(3, time.Minute),
         adapters.Ticker(30*time.Second),
     ))
@@ -161,9 +194,10 @@ Symbol mapping:
   (no longer takes the work argument; pass work to `runnable.New`).
 - `runnable.WithRetry` / `runnable.ResetNever` → `adapters.Retry` /
   `adapters.ResetNever`.
-- `runnable.WithRecoverer` → `adapters.Recovering` with a single
-  `PanicHandler` callback (the two-interface `RecoveryReporter` /
-  `StackPrinter` split is gone).
+- `runnable.WithRecoverer` → `adapters.Recovering()` plus a
+  `runnable.WithPublisher` subscriber listening for
+  `runnable.PanicRecoveredEvent` (the two-interface `RecoveryReporter` /
+  `StackPrinter` callback split is gone).
 - `runnable.Stopping` → `adapters.Stopping`.
 - `runnable.ErrDrainTimedOut` → `adapters.ErrDrainTimedOut`.
 
@@ -174,10 +208,11 @@ the caller waits for `Stop` to return; the drain runs on its own
 fixed-duration timer regardless. If you need a shorter drain budget,
 configure `Draining` with the shorter duration.
 
-**Status.Restarts removed.** The `Restarts` field on `Status` counted
-`WithRetry` re-entries via the deprecated `onStart` coupling; with
-retry moved into adapters it had no clean way to surface. Pending a
-proper event/observer hook in a later release.
+**Status.Restarts is event-driven.** The `Restarts` field on `Status`
+is still present, but it now counts `runnable.RetryEvent`s published
+by `adapters.Retry` (or any other Publisher source) rather than
+being incremented by an `onStart` side-channel from `WithRetry`. No
+call-site change required when using `WithStatus` + `adapters.Retry`.
 
 **NewGroup interaction:** drain-enabled children of `NewGroup` now
 drain when the group is stopped (v0.1 silently bypassed the child's

--- a/adapters/draining.go
+++ b/adapters/draining.go
@@ -54,6 +54,7 @@ func Draining(timeout time.Duration) runnable.Adapter {
 			case err := <-done:
 				return err
 			case <-outerCtx.Done():
+				runnable.Publish(outerCtx, runnable.DrainStartedEvent{Timeout: timeout})
 				close(stopping)
 			}
 
@@ -65,6 +66,7 @@ func Draining(timeout time.Duration) runnable.Adapter {
 			case <-timer.C:
 				cancelWork()
 				<-done
+				runnable.Publish(outerCtx, runnable.DrainTimedOutEvent{})
 				return ErrDrainTimedOut
 			}
 		}

--- a/adapters/draining_test.go
+++ b/adapters/draining_test.go
@@ -172,6 +172,61 @@ func TestDraining_WorkErrorPropagatesWithoutDrain(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 }
 
+func TestDraining_PublishesDrainStarted(t *testing.T) {
+	pub := &capturingPublisher{}
+	started := make(chan struct{})
+
+	work := func(ctx context.Context) error {
+		close(started)
+		<-adapters.Stopping(ctx)
+		return nil
+	}
+
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Draining(1*time.Second)),
+	)
+	go func() { _ = r.Run(context.Background()) }()
+
+	<-started
+	require.NoError(t, r.Stop(context.Background()))
+
+	events := pub.snapshot()
+	require.Len(t, events, 1)
+	ev, ok := events[0].(runnable.DrainStartedEvent)
+	require.True(t, ok, "expected DrainStartedEvent, got %T", events[0])
+	assert.Equal(t, time.Second, ev.Timeout)
+}
+
+func TestDraining_PublishesDrainTimedOut(t *testing.T) {
+	pub := &capturingPublisher{}
+	started := make(chan struct{})
+
+	work := func(ctx context.Context) error {
+		close(started)
+		<-ctx.Done() // ignore Stopping; force the timer to fire
+		return ctx.Err()
+	}
+
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Draining(50*time.Millisecond)),
+	)
+	runErr := make(chan error, 1)
+	go func() { runErr <- r.Run(context.Background()) }()
+
+	<-started
+	require.NoError(t, r.Stop(context.Background()))
+	require.ErrorIs(t, <-runErr, adapters.ErrDrainTimedOut)
+
+	events := pub.snapshot()
+	require.Len(t, events, 2)
+	_, ok := events[0].(runnable.DrainStartedEvent)
+	require.True(t, ok, "first event should be DrainStartedEvent, got %T", events[0])
+	_, ok = events[1].(runnable.DrainTimedOutEvent)
+	require.True(t, ok, "second event should be DrainTimedOutEvent, got %T", events[1])
+}
+
 func TestDraining_RecoversPanicAsError(t *testing.T) {
 	// Regression: panics in work run on Draining's spawned goroutine,
 	// not on the goroutine where outer recover defers live. Without

--- a/adapters/recovering.go
+++ b/adapters/recovering.go
@@ -8,15 +8,12 @@ import (
 	"github.com/0xsequence/runnable"
 )
 
-// PanicHandler observes a panic caught by Recovering. Runs on next's
-// goroutine, so must not block.
-type PanicHandler func(ctx context.Context, rec any, stack []byte)
-
 // Recovering returns an Adapter that converts panics from next into
-// errors and invokes handler (if non-nil). Place inside Draining when
-// both are used, so handler sees the panic before Draining's safety-net
-// recovery formats it.
-func Recovering(handler PanicHandler) runnable.Adapter {
+// errors and publishes a runnable.PanicRecoveredEvent to the Publisher
+// on ctx, if any. Place inside Draining when both are used, so the
+// Publisher sees the panic before Draining's safety-net recovery
+// formats it.
+func Recovering() runnable.Adapter {
 	return func(next runnable.RunFunc) runnable.RunFunc {
 		return func(ctx context.Context) (err error) {
 			defer func() {
@@ -25,9 +22,7 @@ func Recovering(handler PanicHandler) runnable.Adapter {
 					return
 				}
 				stack := debug.Stack()
-				if handler != nil {
-					handler(ctx, rec, stack)
-				}
+				runnable.Publish(ctx, runnable.PanicRecoveredEvent{Recovered: rec, Stack: stack})
 				err = fmt.Errorf("adapters: panic: %v", rec)
 			}()
 			return next(ctx)

--- a/adapters/recovering_test.go
+++ b/adapters/recovering_test.go
@@ -2,6 +2,7 @@ package adapters_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,51 +12,74 @@ import (
 	"github.com/0xsequence/runnable/adapters"
 )
 
+type capturingPublisher struct {
+	mu     sync.Mutex
+	events []any
+}
+
+func (c *capturingPublisher) Publish(event any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *capturingPublisher) snapshot() []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]any, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
 func TestRecovering_TurnsPanicIntoError(t *testing.T) {
-	var captured any
-	handler := func(_ context.Context, rec any, _ []byte) {
-		captured = rec
-	}
-
 	work := func(ctx context.Context) error {
 		panic("boom")
 	}
 
-	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering(handler)))
-	err := r.Run(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "boom")
-	assert.Equal(t, "boom", captured)
-}
-
-func TestRecovering_NilHandlerStillRecovers(t *testing.T) {
-	work := func(ctx context.Context) error {
-		panic("boom")
-	}
-
-	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering(nil)))
+	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering()))
 	err := r.Run(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }
 
-func TestRecovering_PassesThroughOnSuccess(t *testing.T) {
-	called := false
-	handler := func(_ context.Context, rec any, _ []byte) {
-		called = true
+func TestRecovering_PublishesPanicEvent(t *testing.T) {
+	pub := &capturingPublisher{}
+
+	work := func(ctx context.Context) error {
+		panic("boom")
 	}
 
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Recovering()),
+	)
+	err := r.Run(context.Background())
+	require.Error(t, err)
+
+	events := pub.snapshot()
+	require.Len(t, events, 1)
+	ev, ok := events[0].(runnable.PanicRecoveredEvent)
+	require.True(t, ok, "expected PanicRecoveredEvent, got %T", events[0])
+	assert.Equal(t, "boom", ev.Recovered)
+	assert.NotEmpty(t, ev.Stack)
+}
+
+func TestRecovering_NoPublishOnSuccess(t *testing.T) {
+	pub := &capturingPublisher{}
 	work := func(ctx context.Context) error { return nil }
 
-	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering(handler)))
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Recovering()),
+	)
 	require.NoError(t, r.Run(context.Background()))
-	assert.False(t, called, "handler must not fire when next returns normally")
+	assert.Empty(t, pub.snapshot())
 }
 
 func TestRecovering_PassesThroughError(t *testing.T) {
 	work := func(ctx context.Context) error { return assert.AnError }
 
-	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering(nil)))
+	r := runnable.New(work, runnable.WithAdapters(adapters.Recovering()))
 	err := r.Run(context.Background())
 	require.ErrorIs(t, err, assert.AnError)
 }

--- a/adapters/retry.go
+++ b/adapters/retry.go
@@ -13,8 +13,9 @@ const ResetNever time.Duration = 0
 
 // Retry returns an Adapter that re-invokes next up to maxRetries times
 // on non-context errors. If resetAfter > 0 and at least that long has
-// passed since the previous attempt, the budget resets. Retry does not
-// observe Stopping — wrap it inside Draining if you need both.
+// passed since the previous attempt, the budget resets. Each failed
+// attempt publishes a runnable.RetryEvent (Attempt is 1-indexed). Retry
+// does not observe Stopping — wrap it inside Draining if you need both.
 func Retry(maxRetries int, resetAfter time.Duration) runnable.Adapter {
 	return func(next runnable.RunFunc) runnable.RunFunc {
 		return func(ctx context.Context) error {
@@ -35,6 +36,7 @@ func Retry(maxRetries int, resetAfter time.Duration) runnable.Adapter {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return err
 				}
+				runnable.Publish(ctx, runnable.RetryEvent{Attempt: i + 1, Err: err})
 			}
 			return err
 		}

--- a/adapters/retry_test.go
+++ b/adapters/retry_test.go
@@ -68,3 +68,41 @@ func TestRetry_DoesNotRetryContextErrors(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, int32(1), count.Load())
 }
+
+func TestRetry_PublishesEventPerFailedAttempt(t *testing.T) {
+	pub := &capturingPublisher{}
+	var count atomic.Int32
+	work := func(ctx context.Context) error {
+		count.Add(1)
+		return assert.AnError
+	}
+
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Retry(3, adapters.ResetNever)),
+	)
+	err := r.Run(context.Background())
+	require.ErrorIs(t, err, assert.AnError)
+
+	events := pub.snapshot()
+	require.Len(t, events, 3, "one RetryEvent per failed attempt")
+	for i, e := range events {
+		ev, ok := e.(runnable.RetryEvent)
+		require.True(t, ok, "event %d: expected RetryEvent, got %T", i, e)
+		assert.Equal(t, i+1, ev.Attempt, "Attempt is 1-indexed")
+		assert.ErrorIs(t, ev.Err, assert.AnError)
+	}
+}
+
+func TestRetry_DoesNotPublishOnContextError(t *testing.T) {
+	pub := &capturingPublisher{}
+	work := func(ctx context.Context) error { return context.Canceled }
+
+	r := runnable.New(work,
+		runnable.WithPublisher(pub),
+		runnable.WithAdapters(adapters.Retry(3, adapters.ResetNever)),
+	)
+	err := r.Run(context.Background())
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, pub.snapshot(), "context-error give-up must not emit a retry event")
+}

--- a/events.go
+++ b/events.go
@@ -1,0 +1,27 @@
+package runnable
+
+import "time"
+
+// RetryEvent is published by adapters.Retry after a failed attempt
+// (before sleeping or retrying). Attempt is 1-indexed.
+type RetryEvent struct {
+	Attempt int
+	Err     error
+}
+
+// DrainStartedEvent is published by adapters.Draining when the outer
+// ctx is cancelled and the drain window begins.
+type DrainStartedEvent struct {
+	Timeout time.Duration
+}
+
+// DrainTimedOutEvent is published by adapters.Draining when the drain
+// window expires and work is force-cancelled.
+type DrainTimedOutEvent struct{}
+
+// PanicRecoveredEvent is published by adapters.Recovering when it
+// catches a panic from the wrapped work.
+type PanicRecoveredEvent struct {
+	Recovered any
+	Stack     []byte
+}

--- a/examples/ticker-with-drain/main.go
+++ b/examples/ticker-with-drain/main.go
@@ -1,8 +1,9 @@
 // Example: a periodic reconciler that drains gracefully on SIGTERM.
 //
 // Shape: runnable.WithAdapters composing Draining + Recovering + Ticker,
-// driven by signal.NotifyContext. Copy-paste into a service's
-// cmd/.../main.go and replace the reconcile body with your work.
+// driven by signal.NotifyContext. A Publisher subscribes to adapter
+// events. Copy-paste into a service's cmd/.../main.go and replace the
+// reconcile body with your work.
 package main
 
 import (
@@ -28,8 +29,21 @@ func reconcile(ctx context.Context) error {
 	return nil
 }
 
-func panicHandler(_ context.Context, rec any, stack []byte) {
-	fmt.Fprintf(os.Stderr, "tick panic: %v\n%s", rec, stack)
+// logPublisher prints each adapter event. In a real service this would
+// push to a metrics or structured-logging sink.
+type logPublisher struct{}
+
+func (logPublisher) Publish(event any) {
+	switch ev := event.(type) {
+	case runnable.PanicRecoveredEvent:
+		fmt.Fprintf(os.Stderr, "tick panic: %v\n%s", ev.Recovered, ev.Stack)
+	case runnable.DrainStartedEvent:
+		fmt.Printf("drain: started, %s grace window\n", ev.Timeout)
+	case runnable.DrainTimedOutEvent:
+		fmt.Println("drain: timed out, force-cancelled")
+	case runnable.RetryEvent:
+		fmt.Printf("retry: attempt %d failed: %v\n", ev.Attempt, ev.Err)
+	}
 }
 
 func main() {
@@ -38,13 +52,16 @@ func main() {
 
 	// Adapters compose left-to-right (first listed = outermost). Draining
 	// catches outer ctx cancellation and turns it into drain rather than
-	// abort. Recovering sits inside Draining so the handler observes
-	// panics before Draining's safety-net recovery formats them.
-	rc := runnable.New(reconcile, runnable.WithAdapters(
-		adapters.Draining(10*time.Second),
-		adapters.Recovering(panicHandler),
-		adapters.Ticker(2*time.Second),
-	))
+	// abort. Recovering sits inside Draining so the Publisher observes
+	// the panic before Draining's safety-net recovery formats it.
+	rc := runnable.New(reconcile,
+		runnable.WithPublisher(logPublisher{}),
+		runnable.WithAdapters(
+			adapters.Draining(10*time.Second),
+			adapters.Recovering(),
+			adapters.Ticker(2*time.Second),
+		),
+	)
 
 	runErr := make(chan error, 1)
 	go func() {

--- a/publisher.go
+++ b/publisher.go
@@ -47,10 +47,10 @@ func WithPublisher(p Publisher) Option {
 }
 
 func (w *withPublisher) apply(r *runnable) {
-	r.publisher = appendPublisher(r.publisher, w.p)
+	r.publisher = mergePublisher(r.publisher, w.p)
 }
 
-func appendPublisher(existing, next Publisher) Publisher {
+func mergePublisher(existing, next Publisher) Publisher {
 	if next == nil {
 		return existing
 	}

--- a/publisher.go
+++ b/publisher.go
@@ -1,0 +1,68 @@
+package runnable
+
+import "context"
+
+// Publisher receives events from adapters that opt in to publishing.
+// Implementations must not block; if a subscriber needs async dispatch,
+// it should buffer internally.
+type Publisher interface {
+	Publish(event any)
+}
+
+// Publishers is a fanout Publisher that forwards each event to every
+// member in order. Nil entries are skipped.
+type Publishers []Publisher
+
+func (ps Publishers) Publish(event any) {
+	for _, p := range ps {
+		if p != nil {
+			p.Publish(event)
+		}
+	}
+}
+
+type publisherKey struct{}
+
+// PublisherFrom returns the Publisher installed in ctx by runnable.Run,
+// or nil if none. Adapters should prefer Publish, which no-ops when no
+// Publisher is set.
+func PublisherFrom(ctx context.Context) Publisher {
+	p, _ := ctx.Value(publisherKey{}).(Publisher)
+	return p
+}
+
+// Publish forwards event to the Publisher in ctx, or no-ops if none.
+// Use this from adapters that emit observability events.
+func Publish(ctx context.Context, event any) {
+	if p := PublisherFrom(ctx); p != nil {
+		p.Publish(event)
+	}
+}
+
+type withPublisher struct {
+	p Publisher
+}
+
+// WithPublisher installs p as the runnable's event Publisher. Stacks
+// additively across multiple WithPublisher (and WithStatus) Options:
+// subsequent installs fan out to all prior subscribers.
+func WithPublisher(p Publisher) Option {
+	return &withPublisher{p: p}
+}
+
+func (w *withPublisher) apply(r *runnable) {
+	r.publisher = appendPublisher(r.publisher, w.p)
+}
+
+func appendPublisher(existing, next Publisher) Publisher {
+	if next == nil {
+		return existing
+	}
+	if existing == nil {
+		return next
+	}
+	if ps, ok := existing.(Publishers); ok {
+		return append(ps, next)
+	}
+	return Publishers{existing, next}
+}

--- a/publisher.go
+++ b/publisher.go
@@ -2,15 +2,14 @@ package runnable
 
 import "context"
 
-// Publisher receives events from adapters that opt in to publishing.
-// Implementations must not block; if a subscriber needs async dispatch,
-// it should buffer internally.
+// Publisher receives events from adapters. Implementations must not
+// block — buffer internally if async dispatch is needed.
 type Publisher interface {
 	Publish(event any)
 }
 
-// Publishers is a fanout Publisher that forwards each event to every
-// member in order. Nil entries are skipped.
+// Publishers fans out each event to every member in order; nil members
+// are skipped.
 type Publishers []Publisher
 
 func (ps Publishers) Publish(event any) {
@@ -23,16 +22,14 @@ func (ps Publishers) Publish(event any) {
 
 type publisherKey struct{}
 
-// PublisherFrom returns the Publisher installed in ctx by runnable.Run,
-// or nil if none. Adapters should prefer Publish, which no-ops when no
-// Publisher is set.
+// PublisherFrom returns the Publisher installed in ctx, or nil. Adapters
+// should prefer Publish, which no-ops when none is set.
 func PublisherFrom(ctx context.Context) Publisher {
 	p, _ := ctx.Value(publisherKey{}).(Publisher)
 	return p
 }
 
 // Publish forwards event to the Publisher in ctx, or no-ops if none.
-// Use this from adapters that emit observability events.
 func Publish(ctx context.Context, event any) {
 	if p := PublisherFrom(ctx); p != nil {
 		p.Publish(event)
@@ -44,8 +41,7 @@ type withPublisher struct {
 }
 
 // WithPublisher installs p as the runnable's event Publisher. Stacks
-// additively across multiple WithPublisher (and WithStatus) Options:
-// subsequent installs fan out to all prior subscribers.
+// additively across calls (and with WithStatus).
 func WithPublisher(p Publisher) Option {
 	return &withPublisher{p: p}
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,0 +1,65 @@
+package runnable_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xsequence/runnable"
+)
+
+type capturingPublisher struct {
+	mu     sync.Mutex
+	events []any
+}
+
+func (c *capturingPublisher) Publish(event any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *capturingPublisher) snapshot() []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]any, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+func TestWithPublisher_InstalledInRunCtx(t *testing.T) {
+	p := &capturingPublisher{}
+	var observed runnable.Publisher
+
+	r := runnable.New(func(ctx context.Context) error {
+		observed = runnable.PublisherFrom(ctx)
+		return nil
+	}, runnable.WithPublisher(p))
+
+	require.NoError(t, r.Run(context.Background()))
+	assert.Same(t, p, observed, "PublisherFrom should return the publisher installed via WithPublisher")
+}
+
+func TestPublish_NoOpWithoutPublisher(t *testing.T) {
+	r := runnable.New(func(ctx context.Context) error {
+		runnable.Publish(ctx, "anything") // must not panic when no publisher set
+		return nil
+	})
+	require.NoError(t, r.Run(context.Background()))
+}
+
+func TestWithPublisher_StacksAdditively(t *testing.T) {
+	a, b := &capturingPublisher{}, &capturingPublisher{}
+
+	r := runnable.New(func(ctx context.Context) error {
+		runnable.Publish(ctx, "hello")
+		return nil
+	}, runnable.WithPublisher(a), runnable.WithPublisher(b))
+
+	require.NoError(t, r.Run(context.Background()))
+	assert.Equal(t, []any{"hello"}, a.snapshot())
+	assert.Equal(t, []any{"hello"}, b.snapshot())
+}

--- a/runnable.go
+++ b/runnable.go
@@ -31,6 +31,7 @@ type runnable struct {
 	isRunning bool
 	onStart   func()
 	onStop    func()
+	publisher Publisher
 
 	mu sync.Mutex
 }
@@ -89,6 +90,9 @@ func (r *runnable) Run(ctx context.Context) error {
 
 	r.isRunning = true
 	r.runCtx, r.runCancel = context.WithCancel(ctx)
+	if r.publisher != nil {
+		r.runCtx = context.WithValue(r.runCtx, publisherKey{}, r.publisher)
+	}
 	r.runStop = make(chan bool)
 
 	runCtx := r.runCtx

--- a/status_integration_test.go
+++ b/status_integration_test.go
@@ -1,0 +1,38 @@
+package runnable_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xsequence/runnable"
+	"github.com/0xsequence/runnable/adapters"
+)
+
+// Lives in runnable_test (not in the adapters package) because it
+// crosses both: WithStatus is core, Retry is in adapters.
+func TestStatusRestartsCountedFromRetryAdapter(t *testing.T) {
+	store := runnable.NewStatusStore()
+	var count atomic.Int32
+
+	r := runnable.New(func(ctx context.Context) error {
+		c := count.Add(1)
+		if c < 3 {
+			return assert.AnError
+		}
+		return nil
+	},
+		runnable.WithStatus("recon", store),
+		runnable.WithAdapters(adapters.Retry(5, adapters.ResetNever)),
+	)
+
+	require.NoError(t, r.Run(context.Background()))
+
+	s := store.Get()
+	// Two failed attempts before success → two RetryEvents → Restarts = 2.
+	assert.Equal(t, 2, s["recon"].Restarts)
+	assert.Equal(t, false, s["recon"].Running)
+}

--- a/with_status.go
+++ b/with_status.go
@@ -130,7 +130,7 @@ func (w *withStatus) apply(r *runnable) {
 		}
 	}
 
-	r.publisher = appendPublisher(r.publisher, &statusPublisher{store: w.store, id: w.runnableID})
+	r.publisher = mergePublisher(r.publisher, &statusPublisher{store: w.store, id: w.runnableID})
 }
 
 // statusPublisher tags events with the runnable ID before routing them

--- a/with_status.go
+++ b/with_status.go
@@ -10,6 +10,7 @@ type StatusMap map[string]Status
 
 type Status struct {
 	Running   bool       `json:"running"`
+	Restarts  int        `json:"restarts"`
 	StartTime time.Time  `json:"start_time"`
 	EndTime   *time.Time `json:"end_time,omitempty"`
 	LastError error      `json:"last_error"`
@@ -17,6 +18,7 @@ type Status struct {
 
 type StatusStore struct {
 	running   map[string]bool
+	restarts  map[string]int
 	startTime map[string]time.Time
 	endTime   map[string]time.Time
 	lastError map[string]error
@@ -27,6 +29,7 @@ type StatusStore struct {
 func NewStatusStore() *StatusStore {
 	return &StatusStore{
 		running:   make(map[string]bool),
+		restarts:  make(map[string]int),
 		startTime: make(map[string]time.Time),
 		endTime:   make(map[string]time.Time),
 		lastError: make(map[string]error),
@@ -41,6 +44,10 @@ func (s *StatusStore) Get() StatusMap {
 	for id, running := range s.running {
 		st := Status{
 			Running: running,
+		}
+
+		if restarts, ok := s.restarts[id]; ok {
+			st.Restarts = restarts
 		}
 
 		if startTime, ok := s.startTime[id]; ok {
@@ -60,6 +67,17 @@ func (s *StatusStore) Get() StatusMap {
 	}
 
 	return sm
+}
+
+// publish dispatches an adapter event into the per-id slot in the store.
+// Lifecycle state (Running, StartTime, etc.) is set by withStatus's
+// onStart/onStop hooks, not here.
+func (s *StatusStore) publish(id string, event any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := event.(RetryEvent); ok {
+		s.restarts[id]++
+	}
 }
 
 type withStatus struct {
@@ -111,6 +129,19 @@ func (w *withStatus) apply(r *runnable) {
 			onStopRunnable()
 		}
 	}
+
+	r.publisher = appendPublisher(r.publisher, &statusPublisher{store: w.store, id: w.runnableID})
+}
+
+// statusPublisher tags events with the runnable ID before routing them
+// into the shared StatusStore.
+type statusPublisher struct {
+	store *StatusStore
+	id    string
+}
+
+func (p *statusPublisher) Publish(event any) {
+	p.store.publish(p.id, event)
 }
 
 func WithStatus(id string, store *StatusStore) Option {

--- a/with_status_test.go
+++ b/with_status_test.go
@@ -52,4 +52,24 @@ func TestWithStatus(t *testing.T) {
 		assert.Equal(t, false, s["test"].Running)
 		assert.Equal(t, assert.AnError, s["test"].LastError)
 	})
+
+	t.Run("with status, restarts counted via RetryEvent", func(t *testing.T) {
+		// adapters.Retry publishes RetryEvent; WithStatus subscribes via a
+		// statusPublisher tagged with the runnable id. Restarts in the
+		// resulting Status is the count of those events. We exercise the
+		// publish path directly without importing adapters (cycle).
+		store := NewStatusStore()
+		r := New(func(ctx context.Context) error {
+			p := PublisherFrom(ctx)
+			require.NotNil(t, p, "WithStatus must install a Publisher on runCtx")
+			p.Publish(RetryEvent{Attempt: 1, Err: assert.AnError})
+			p.Publish(RetryEvent{Attempt: 2, Err: assert.AnError})
+			return nil
+		}, WithStatus("test", store))
+
+		require.NoError(t, r.Run(context.Background()))
+
+		s := store.Get()
+		assert.Equal(t, 2, s["test"].Restarts)
+	})
 }


### PR DESCRIPTION
Adds an observability layer for adapters. A `runnable.Publisher` interface (single `Publish(any)` method) is installed onto the runnable's ctx via `runnable.WithPublisher`; adapters call `runnable.Publish(ctx, event)` to emit typed events. `StatusStore` becomes a `Publisher` and `Status.Restarts` is back — counted from `RetryEvent` instead of the deprecated `WithRetry` `onStart` side-channel.

Stacked on #4 — review against `feat/drain-and-ticker`, not `master`.

Closes marino39's #2 quick-glance item (StatusStore refactor so adapters can store stuff).

---

## Commits

- `01eed91` — `Publisher` interface + `Publishers` fanout + `WithPublisher` Option + ctx helpers (`PublisherFrom`, `Publish`). Event types (`RetryEvent`, `DrainStartedEvent`, `DrainTimedOutEvent`, `PanicRecoveredEvent`).
- `94d8068` — Wire publish calls into Retry / Draining / Recovering. `Recovering` drops its `PanicHandler` argument (single way to handle panics: subscribe via `Publisher`).
- `8700487` — `WithStatus` registers a tagged statusPublisher; `Status.Restarts` increments from `RetryEvent`. Integration test (in `runnable_test` to avoid an import cycle) verifies `WithStatus` + `adapters.Retry` end-to-end.
- `5616225` — README "Observability via Publisher" section + updated migration table.

## Shape

```go
type log struct{}

func (log) Publish(event any) {
    switch ev := event.(type) {
    case runnable.RetryEvent:
        slog.Warn("retry", "attempt", ev.Attempt, "err", ev.Err)
    case runnable.PanicRecoveredEvent:
        slog.Error("panic", "err", ev.Recovered)
    }
}

r := runnable.New(work,
    runnable.WithStatus("recon", store), // store sees RetryEvent → Restarts++
    runnable.WithPublisher(log{}),       // log sees the same events
    runnable.WithAdapters(
        adapters.Retry(3, time.Minute),
        adapters.Recovering(),
    ),
)
```

## Test plan
- `go test -race -count=1 ./...` — passes.
- Vacuous-test check: commented out the `r.publisher = mergePublisher(...)` wiring in `WithStatus.apply` and confirmed `TestStatusRestartsCountedFromRetryAdapter` fails (expected 2, got 0) before restoring.
- `golangci-lint run ./...` — clean.

## Notes
- **Publisher signature is `Publish(event any)`** — single method, no source/ID parameter. `WithStatus` tags events with the runnable ID via an internal `statusPublisher` wrapper.
- **Multi-publisher composition:** `WithPublisher` (and `WithStatus`) stack additively via a `Publishers` fanout type. Order doesn't matter.
- **Synchronous dispatch:** `Publisher.Publish` runs on the goroutine that emits. Documented in README. Subscribers needing async dispatch should buffer internally.
- **Breaking change carried in this stack:** `adapters.Recovering()` no longer takes a `PanicHandler`. Migration is one extra Option (`WithPublisher`) — documented.
